### PR TITLE
Allow "--exclusive" to override other flags

### DIFF
--- a/src/flock.c
+++ b/src/flock.c
@@ -181,6 +181,7 @@ int main(int argc, char *argv[]) {
 		switch (opt) {
 		case 'x':
 		case 'e':
+			type = LOCK_EX;
 			break;
 		case 's':
 			type = LOCK_SH;


### PR DESCRIPTION
The "--exclusive" option and its equivalents should not be treated as
no-op. They should explicitly set the lock type so when this flag is
used after another lock-type option it will take precedence over the
others. All of the other lock-type options already work this way.