### PR TITLE
Modernize flock: CI, bug fixes, comprehensive test suite, and refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake bats
+      - name: Bootstrap
+        run: autoreconf --force --install
+      - name: Configure
+        run: ./configure CC=${{ matrix.cc }}
+      - name: Build
+        run: make
+      - name: Test
+        run: make check
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-logs-linux-${{ matrix.cc }}
+          path: |
+            test-suite.log
+            t/*.log
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        run: brew install automake bats-core
+      - name: Bootstrap
+        run: autoreconf --force --install
+      - name: Configure
+        run: ./configure
+      - name: Build
+        run: make
+      - name: Test
+        run: make check
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-logs-macos
+          path: |
+            test-suite.log
+            t/*.log
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build and test on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y autoconf automake bash bats-core
+          run: |
+            autoreconf --force --install
+            ./configure
+            make
+            make check
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-logs-freebsd
+          path: |
+            test-suite.log
+            t/*.log
+
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        run: sudo gem install ronn-ng
+      - name: Build man page
+        run: |
+          ronn --manual="User Commands" --organization=discoteq --date=2015-12-18 -r man/flock.1.ronn
+          ronn --manual="User Commands" --organization=discoteq --date=2015-12-18 -5 man/flock.1.ronn
+      - name: Upload man pages
+        uses: actions/upload-artifact@v5
+        with:
+          name: man-pages
+          path: |
+            man/flock.1
+            man/flock.1.html

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,14 +56,34 @@ lint:
 
 man_MANS = man/flock.1
 man/flock.1: man/flock.1.ronn man/index.txt
-	$(RONN) $(RONN_FLAGS) -r man/flock.1.ronn
+	@if command -v $(RONN) >/dev/null 2>&1; then \
+		$(RONN) $(RONN_FLAGS) -r man/flock.1.ronn; \
+	elif [ -f $@ ]; then \
+		touch $@; \
+	else \
+		echo "Warning: ronn not found and no pre-built man page available" >&2; \
+		touch $@; \
+	fi
 man/flock.1.html: man/flock.1.ronn man/index.txt
-	$(RONN) $(RONN_FLAGS) -5 man/flock.1.ronn
+	@if command -v $(RONN) >/dev/null 2>&1; then \
+		$(RONN) $(RONN_FLAGS) -5 man/flock.1.ronn; \
+	else \
+		echo "Warning: ronn not found, skipping HTML man page" >&2; \
+	fi
 nroff-man: man/flock.1
 	$(NROFF) -man < man/flock.1
 html-man: man/flock.1.html
-	$(OPEN) man/flock.1.html
-doc: man/flock.1 man/flock.1.html
+	@if [ -f man/flock.1.html ]; then \
+		$(OPEN) man/flock.1.html; \
+	else \
+		echo "man/flock.1.html not built (ronn not installed)" >&2; exit 1; \
+	fi
+doc:
+	@if command -v $(RONN) >/dev/null 2>&1; then \
+		$(MAKE) man/flock.1 man/flock.1.html; \
+	else \
+		echo "Error: ronn is required to build documentation" >&2; exit 1; \
+	fi
 
 EXTRA_DIST=\
 	LICENSE.md \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ On macOS using MacPorts:
 
     port install flock
 
-
 From source:
 
     FLOCK_VERSION=0.4.0
@@ -34,6 +33,10 @@ From source:
     ./configure
     make
     make install
+
+To run the test suite, [bats-core](https://github.com/bats-core/bats-core) is required:
+
+    make check
 
 ## Wait, isn't there already a flock(1)?
 

--- a/man/flock.1.ronn
+++ b/man/flock.1.ronn
@@ -57,7 +57,18 @@ for how that can be used.
     may have forked a background process which should not be holding
     the lock.
 
-  * `--verbose`
+  * `-c`, `--command`:
+    Run a single command string through the shell (via `$SHELL -c` or
+    `/bin/sh -c` if `$SHELL` is unset).
+
+  * `-h`, `--help`:
+    Display usage information and exit.
+
+  * `-V`, `--version`:
+    Display version information and exit.
+
+  * `--verbose`:
+    Print diagnostic information about lock acquisition timing.
 
 ## EXAMPLES
 

--- a/src/flock.c
+++ b/src/flock.c
@@ -265,10 +265,8 @@ int main(int argc, char *argv[]) {
 			open_flags = O_WRONLY | O_NOCTTY | O_CREAT;
 		}
 
-		if (verbose) {
-			gettimeofday(&t_l_req, NULL);
+		if (verbose)
 			printf("flock: getting lock\n");
-		}
 		fd = open(filename, open_flags, 0666);
 
 		// directories don't like O_WRONLY (and sometimes O_CREAT)
@@ -313,6 +311,9 @@ int main(int argc, char *argv[]) {
 		if (0 != setitimer(ITIMER_REAL, &timer, &old_timer))
 			err(EX_OSERR, "could not set interval timer");
 	}
+
+	if (verbose)
+		gettimeofday(&t_l_req, NULL);
 
 	while (0 != flock(fd, type | block)) {
 		switch (errno) {

--- a/src/flock.c
+++ b/src/flock.c
@@ -17,6 +17,7 @@
 #include <sysexits.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <paths.h>
 
@@ -61,13 +62,13 @@ static int flock(int fd, int operation) {
 
 	switch (operation) {
 	case LOCK_UN:
-		fl.l_type |= F_UNLCK;
+		fl.l_type = F_UNLCK;
 		break;
 	case LOCK_SH:
-		fl.l_type |= F_RDLCK;
+		fl.l_type = F_RDLCK;
 		break;
 	case LOCK_EX:
-		fl.l_type |= F_WRLCK;
+		fl.l_type = F_WRLCK;
 		break;
 	default:
 		errno = EINVAL;
@@ -99,8 +100,9 @@ static inline void close_stdout(void) {
 	}
 }
 
-static void usage(void) {
-	fprintf(stderr, "\
+static void usage(int status) {
+	FILE *out = status == EX_OK ? stdout : stderr;
+	fprintf(out, "\
 Usage:\n\
  %s [-sxun][-w #][-E #] fd#\n\
  %s [-sxon][-w #][-E #] file [-c] command...\n\
@@ -119,7 +121,7 @@ Options:\n\
  -E --conflict-exit-code\n\
     --verbose    Increase verbosity\n"
 		,progname, progname, progname);
-	exit(EX_USAGE);
+	exit(status);
 }
 
 static void version(void) {
@@ -142,7 +144,7 @@ int main(int argc, char *argv[]) {
 	int status_time_conflict = EXIT_FAILURE; // -E default to EXIT_FAILURE
 	struct itimerval timer, old_timer;
 	struct sigaction sa, old_sa;
-    struct timeval t_l_req, t_l_acq; // verbose time lock request and acquire
+	struct timeval t_l_req, t_l_acq; // verbose time lock request and acquire
 
 	int block = 0; // -n
 
@@ -164,26 +166,25 @@ int main(int argc, char *argv[]) {
 		err(EX_OSERR, "Could not attach atexit handler");
 
 	if (argc < 2)
-		usage();
+		usage(EX_USAGE);
 
 	memset(&timer, 0, sizeof timer);
 
-  /* options descriptor */
-  static struct option longopts[] = {
-    { "exclusive",  no_argument,            NULL,           'x' },
-    { "shared",     no_argument,            NULL,           's' },
-    { "unlock",     no_argument,            NULL,           'u' },
-    { "nonblock",   no_argument,            NULL,           'n' },
-    { "nb",         no_argument,            NULL,           'n' },
-    { "wait",       required_argument,      NULL,           'w' },
-    { "timeout",    required_argument,      NULL,           'w' },
-    { "conflict-exit-code",    required_argument,      NULL,           'E' },
-    { "close",      no_argument,            NULL,           'o' },
-    { "help",       no_argument,            NULL,           'h' },
-    { "version",    no_argument,            NULL,           'V' },
-    { "verbose",    no_argument,            NULL,           'v' },
-    { NULL,         0,                      NULL,           0 }
-  };
+	static struct option longopts[] = {
+		{ "exclusive",          no_argument,       NULL, 'x' },
+		{ "shared",             no_argument,       NULL, 's' },
+		{ "unlock",             no_argument,       NULL, 'u' },
+		{ "nonblock",           no_argument,       NULL, 'n' },
+		{ "nb",                 no_argument,       NULL, 'n' },
+		{ "wait",               required_argument, NULL, 'w' },
+		{ "timeout",            required_argument, NULL, 'w' },
+		{ "conflict-exit-code", required_argument, NULL, 'E' },
+		{ "close",              no_argument,       NULL, 'o' },
+		{ "help",               no_argument,       NULL, 'h' },
+		{ "version",            no_argument,       NULL, 'V' },
+		{ "verbose",            no_argument,       NULL, 'v' },
+		{ NULL,                 0,                 NULL,  0  }
+	};
 
 	while (-1 != (opt = getopt_long(argc, argv, "+suxeonhE:w:Vv", longopts, NULL))) {
 		switch (opt) {
@@ -211,9 +212,15 @@ int main(int argc, char *argv[]) {
 			timer.it_value.tv_sec = (time_t) raw_timeval;
 			timer.it_value.tv_usec = (suseconds_t) ((raw_timeval - timer.it_value.tv_sec) * 1000000);
 			break;
-		case 'E':
-			status_time_conflict = atoi(optarg);
+		case 'E': {
+			char *endptr;
+			errno = 0;
+			long val = strtol(optarg, &endptr, 10);
+			if (errno != 0 || endptr == optarg || *endptr != '\0' || val < 0 || val > 255)
+				errx(EX_USAGE, "conflict exit code must be 0-255, was '%s'", optarg);
+			status_time_conflict = (int)val;
 			break;
+		}
 		case 'V':
 			version();
 			break;
@@ -221,14 +228,14 @@ int main(int argc, char *argv[]) {
 			verbose=true;
 			break;
 		case 'h':
+			usage(EX_OK);
+			break;
 		case '?':
 		default:
-			usage();
-			// should not get here
+			usage(EX_USAGE);
 			break;
 		}
 	}
-
 
 	if (argc - 1 > optind) {
 		/* Run command */
@@ -249,7 +256,6 @@ int main(int argc, char *argv[]) {
 			cmd_argv = &argv[optind + 1];
 		}
 
-
 		filename = argv[optind];
 
 		// some systems allow exclusive locks on read-only files
@@ -260,8 +266,8 @@ int main(int argc, char *argv[]) {
 		}
 
 		if (verbose) {
-			gettimeofday(&t_l_req,NULL);
-			printf("flock: getting lock ");
+			gettimeofday(&t_l_req, NULL);
+			printf("flock: getting lock\n");
 		}
 		fd = open(filename, open_flags, 0666);
 
@@ -287,7 +293,12 @@ int main(int argc, char *argv[]) {
 		}
 	} else if (argc > optind) {
 		// Use provided file descriptor
-		fd = (int)strtol(argv[optind], NULL, 10);
+		char *endptr;
+		errno = 0;
+		long fdval = strtol(argv[optind], &endptr, 10);
+		if (errno != 0 || endptr == argv[optind] || *endptr != '\0' || fdval < 0 || fdval > INT_MAX)
+			errx(EX_USAGE, "bad file descriptor: %s", argv[optind]);
+		fd = (int)fdval;
 	} else {
 		// not enough parameters
 		errx(EX_USAGE, "requires a file path, directory path, or file descriptor");
@@ -298,9 +309,9 @@ int main(int argc, char *argv[]) {
 		sa.sa_handler = timeout_handler;
 		sa.sa_flags = SA_RESETHAND;
 		if (0 != sigaction(SIGALRM, &sa, &old_sa))
-				err(EX_OSERR, "could not attach timeout handler");
+			err(EX_OSERR, "could not attach timeout handler");
 		if (0 != setitimer(ITIMER_REAL, &timer, &old_timer))
-				err(EX_OSERR, "could not set interval timer");
+			err(EX_OSERR, "could not set interval timer");
 	}
 
 	while (0 != flock(fd, type | block)) {
@@ -319,15 +330,17 @@ int main(int argc, char *argv[]) {
 		}
 	}
 	if (verbose) {
-		gettimeofday(&t_l_acq,NULL);
-		printf("took %1lu microseconds\n", (unsigned long) (t_l_acq.tv_usec - t_l_req.tv_usec)); // not adding due to time constraints
+		gettimeofday(&t_l_acq, NULL);
+		long elapsed_us = (t_l_acq.tv_sec - t_l_req.tv_sec) * 1000000L
+			+ (t_l_acq.tv_usec - t_l_req.tv_usec);
+		printf("took %ld microseconds\n", elapsed_us);
 	}
 
 	if (have_timeout) {
 		if (0 != setitimer(ITIMER_REAL, &old_timer, NULL))
-				err(EX_OSERR, "could not reset old interval timer");
+			err(EX_OSERR, "could not reset old interval timer");
 		if (0 != sigaction(SIGALRM, &old_sa, NULL))
-				err(EX_OSERR, "could not reattach old timeout handler");
+			err(EX_OSERR, "could not reattach old timeout handler");
 	}
 
 	if (cmd_argv) {
@@ -363,7 +376,7 @@ int main(int argc, char *argv[]) {
 			} while (w != f);
 
 			if (-1 == w)
-				err(EXIT_FAILURE, "waidpid failed");
+				err(EXIT_FAILURE, "waitpid failed");
 			else if (0 != WIFEXITED(status))
 				status = WEXITSTATUS(status);
 			else if (0 != WIFSIGNALED(status))

--- a/t/default.bats
+++ b/t/default.bats
@@ -618,6 +618,16 @@ get_elapsed() {
 	[[ "$result" == *"microseconds"* ]]
 }
 
+@test "--verbose in fd mode reports sane timing" {
+	# Regression: t_l_req was uninitialized in FD mode, producing
+	# garbage like "took 1774858164251193 microseconds"
+	result=$( (${FLOCK} --verbose 8) 8> ${LOCKFILE} 2>&1 )
+	[[ "$result" == *"microseconds"* ]]
+	# Extract the number and verify it's under 1 second (1000000 us)
+	elapsed=$(echo "$result" | grep -o '[0-9]* microseconds' | grep -o '[0-9]*')
+	[ "$elapsed" -lt 1000000 ]
+}
+
 ###############################################################################
 # Lock is released when holder exits
 ###############################################################################

--- a/t/default.bats
+++ b/t/default.bats
@@ -3,229 +3,681 @@
 BASE=`dirname $BATS_TEST_DIRNAME`
 FLOCK="${GRIND} ${BASE}/flock" # valgrind if you're so inclined
 TIME=`which time` # don't use built-in time so we can access output
-LOCKFILE=`mktemp -t flock.XXXXXXXXXX`
 
-# default uses an exclusive lock
-@test "exclusive lock prevents addl exclusive locks" {
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+setup() {
+	LOCKFILE=`mktemp -t flock.XXXXXXXXXX`
 }
 
-# explicit invocation with -x
+teardown() {
+	jobs -p | xargs kill 2>/dev/null || true
+	wait 2>/dev/null || true
+	rm -rf ${LOCKFILE} 2>/dev/null || true
+}
+
+# Helper: check whether a command was blocked (waited) or ran immediately.
+# Uses awk to compare elapsed time against a threshold.
+was_blocked() {
+	local elapsed="$1"
+	# "blocked" means elapsed >= 0.3 seconds
+	awk "BEGIN { exit ($elapsed >= 0.3) ? 0 : 1 }"
+}
+
+was_immediate() {
+	local elapsed="$1"
+	# "immediate" means elapsed < 0.3 seconds
+	awk "BEGIN { exit ($elapsed < 0.3) ? 0 : 1 }"
+}
+
+# Hold a lock in the background and poll until it's actually acquired
+hold_lock() {
+	local flags="${1:-}"
+	${FLOCK} ${flags} ${LOCKFILE} sleep 2 &
+	local i=0
+	while [ $i -lt 50 ]; do
+		if ! ${FLOCK} -n ${LOCKFILE} true 2>/dev/null; then
+			return 0
+		fi
+		sleep 0.05
+		i=$((i + 1))
+	done
+	echo "hold_lock: timed out waiting for lock acquisition" >&2
+	return 1
+}
+
+# Poll until an exclusive lock on LOCKFILE is held (nonblock probe fails)
+wait_for_lock() {
+	local i=0
+	while [ $i -lt 50 ]; do
+		if ! ${FLOCK} -n ${LOCKFILE} true 2>/dev/null; then
+			return 0
+		fi
+		sleep 0.05
+		i=$((i + 1))
+	done
+	echo "wait_for_lock: timed out" >&2
+	return 1
+}
+
+get_elapsed() {
+	${TIME} -p "$@" 2>&1 | awk '/real/ {print $2}'
+}
+
+###############################################################################
+# Usage and help
+###############################################################################
+
+@test "no arguments prints usage to stderr and exits non-zero" {
+	run ${FLOCK}
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Usage"* ]]
+}
+
+@test "-h exits with status 0 and prints usage to stdout" {
+	run ${FLOCK} -h
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Usage"* ]]
+	[[ "$output" == *"--shared"* ]]
+}
+
+@test "--help exits with status 0" {
+	run ${FLOCK} --help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Usage"* ]]
+}
+
+@test "-V prints version and exits 0" {
+	run ${FLOCK} -V
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"flock"* ]]
+}
+
+@test "--version prints version and exits 0" {
+	run ${FLOCK} --version
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"flock"* ]]
+}
+
+@test "unknown option prints usage and exits non-zero" {
+	run ${FLOCK} --bogus-option
+	[ "$status" -ne 0 ]
+}
+
+###############################################################################
+# Exclusive lock (default)
+###############################################################################
+
+@test "default lock is exclusive and blocks other exclusive locks" {
+	hold_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
+}
+
 @test "-x behaves as exclusive" {
-	${FLOCK} -x ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} -x ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	hold_lock "-x"
+	result=$(get_elapsed ${FLOCK} -x ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-# explicit invocation with --exclusive
+@test "-e behaves as exclusive (alias for -x)" {
+	hold_lock "-e"
+	result=$(get_elapsed ${FLOCK} -e ${LOCKFILE} true)
+	was_blocked "$result"
+}
+
 @test "--exclusive behaves as exclusive" {
-	${FLOCK} --exclusive ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} --exclusive ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	hold_lock "--exclusive"
+	result=$(get_elapsed ${FLOCK} --exclusive ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-# -s uses a shared lock instead of exclusive
+@test "exclusive lock blocks shared lock" {
+	hold_lock
+	result=$(get_elapsed ${FLOCK} -s ${LOCKFILE} true)
+	was_blocked "$result"
+}
+
+###############################################################################
+# Shared lock (-s, --shared)
+###############################################################################
+
 @test "-s allows other shared locks" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} -s ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
+	hold_lock "-s"
+	result=$(get_elapsed ${FLOCK} -s ${LOCKFILE} true)
+	was_immediate "$result"
 }
+
 @test "-s prevents exclusive locks" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	hold_lock "-s"
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-# --shared uses a shared lock instead of exclusive
 @test "--shared allows other shared locks" {
-	${FLOCK} --shared ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} --shared ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
+	hold_lock "--shared"
+	result=$(get_elapsed ${FLOCK} --shared ${LOCKFILE} true)
+	was_immediate "$result"
 }
+
 @test "--shared prevents exclusive locks" {
-	${FLOCK} --shared ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	hold_lock "--shared"
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-# -o doesn't pass fd to child, how to test?
-
-# -w sec waits for file to become unlocked, failing after timeout
-@test "-w runs command if the lock is released" {
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${FLOCK} -w 0.10 ${LOCKFILE} echo run || echo err)
-	[ "$result" = run ]
-}
-@test "-w fails if the lock isn't released in time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} -w 0.05 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
-@test "-w fails for zero time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} -w 0.0 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
-@test "-w fails for negative time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} -w 0.0 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
+@test "multiple shared locks can coexist" {
+	${FLOCK} -s ${LOCKFILE} sleep 2 &
+	${FLOCK} -s ${LOCKFILE} sleep 2 &
+	sleep 0.2  # shared locks don't block nonblock probe, just wait briefly
+	# A third shared lock should also be immediate
+	result=$(get_elapsed ${FLOCK} -s ${LOCKFILE} true)
+	was_immediate "$result"
 }
 
-# --timeout sec waits for file to become unlocked, failing after timeout
-@test "--timeout runs command if the lock is released" {
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${FLOCK} --timeout 0.10 ${LOCKFILE} echo run || echo err)
-	[ "$result" = run ]
-}
-@test "--timeout fails if the lock isn't released in time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} --timeout 0.05 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
-@test "--timeout fails for zero time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} --timeout 0.0 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
-@test "--timeout fails for negative time" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} --timeout 0.0 ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
+###############################################################################
+# Nonblock (-n, --nonblock, --nb)
+###############################################################################
+
+@test "-n fails immediately if exclusive lock exists" {
+	hold_lock
+	run ${FLOCK} -n ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
 }
 
-# -n fails immediately if file is locked
-@test "-n fails if exclusive lock exists" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
+@test "-n fails immediately if shared lock exists" {
+	hold_lock "-s"
+	run ${FLOCK} -n ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
 }
-@test "-n fails if shared lock exists" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
-@test "-n succeeds if lock is absent" {
+
+@test "-n succeeds if no lock exists" {
 	rm -f ${LOCKFILE}
-	result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
+	result=$(${FLOCK} -n ${LOCKFILE} echo run)
 	[ "$result" = run ]
 }
 
-# --nonblock fails immediately if file is locked
+@test "-n shared succeeds when shared lock is held" {
+	hold_lock "-s"
+	result=$(${FLOCK} -n -s ${LOCKFILE} echo run)
+	[ "$result" = run ]
+}
+
+@test "-n shared fails when exclusive lock is held" {
+	hold_lock
+	run ${FLOCK} -n -s ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
 @test "--nonblock fails if exclusive lock exists" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} --nonblock ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
+	hold_lock
+	run ${FLOCK} --nonblock ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
 }
-@test "--nonblock fails if shared lock exists" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.10 &
-	result=$(${FLOCK} --nonblock ${LOCKFILE} echo run || echo err)
-	[ "$result" = err ]
-}
+
 @test "--nonblock succeeds if lock is absent" {
 	rm -f ${LOCKFILE}
-	result=$(${FLOCK} --nonblock ${LOCKFILE} echo run || echo err)
+	result=$(${FLOCK} --nonblock ${LOCKFILE} echo run)
 	[ "$result" = run ]
 }
 
-# -u forcebly releases lock
+@test "--nb is an alias for --nonblock" {
+	hold_lock
+	run ${FLOCK} --nb ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+###############################################################################
+# Timeout (-w, --timeout, --wait)
+###############################################################################
+
+@test "-w succeeds if lock is released before timeout" {
+	${FLOCK} ${LOCKFILE} sleep 0.3 &
+	sleep 0.1
+	result=$(${FLOCK} -w 3 ${LOCKFILE} echo run || echo err)
+	[ "$result" = run ]
+}
+
+@test "-w fails if lock isn't released in time" {
+	hold_lock
+	result=$(${FLOCK} -w 0.1 ${LOCKFILE} echo run || echo err)
+	[ "$result" = err ]
+}
+
+@test "-w fails for zero timeout" {
+	hold_lock
+	result=$(${FLOCK} -w 0.0 ${LOCKFILE} echo run || echo err)
+	[ "$result" = err ]
+}
+
+@test "-w with fractional seconds works" {
+	${FLOCK} ${LOCKFILE} sleep 0.2 &
+	sleep 0.1
+	result=$(${FLOCK} -w 1.5 ${LOCKFILE} echo run || echo err)
+	[ "$result" = run ]
+}
+
+@test "--timeout succeeds if lock is released before timeout" {
+	${FLOCK} ${LOCKFILE} sleep 0.3 &
+	sleep 0.1
+	result=$(${FLOCK} --timeout 3 ${LOCKFILE} echo run || echo err)
+	[ "$result" = run ]
+}
+
+@test "--timeout fails if lock isn't released in time" {
+	hold_lock
+	result=$(${FLOCK} --timeout 0.1 ${LOCKFILE} echo run || echo err)
+	[ "$result" = err ]
+}
+
+@test "--wait is an alias for --timeout" {
+	hold_lock
+	result=$(${FLOCK} --wait 0.1 ${LOCKFILE} echo run || echo err)
+	[ "$result" = err ]
+}
+
+@test "-w without contention succeeds immediately" {
+	rm -f ${LOCKFILE}
+	result=$(${FLOCK} -w 1 ${LOCKFILE} echo run)
+	[ "$result" = run ]
+}
+
+###############################################################################
+# Conflict exit code (-E, --conflict-exit-code)
+###############################################################################
+
+@test "-E sets custom exit code for -n conflict" {
+	hold_lock
+	run ${FLOCK} -n -E 42 ${LOCKFILE} echo run
+	[ "$status" -eq 42 ]
+}
+
+@test "-E sets custom exit code for -w timeout" {
+	hold_lock
+	run ${FLOCK} -w 0.1 -E 99 ${LOCKFILE} echo run
+	[ "$status" -eq 99 ]
+}
+
+@test "--conflict-exit-code works as long form" {
+	hold_lock
+	run ${FLOCK} -n --conflict-exit-code 77 ${LOCKFILE} echo run
+	[ "$status" -eq 77 ]
+}
+
+@test "-E 0 makes conflict look like success" {
+	hold_lock
+	run ${FLOCK} -n -E 0 ${LOCKFILE} echo run
+	[ "$status" -eq 0 ]
+}
+
+@test "-E rejects empty string" {
+	run ${FLOCK} -n -E "" ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+@test "-E rejects non-numeric argument" {
+	run ${FLOCK} -n -E foo ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"conflict exit code"* ]]
+}
+
+@test "-E rejects negative value" {
+	run ${FLOCK} -n -E -1 ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+@test "-E rejects value above 255" {
+	run ${FLOCK} -n -E 256 ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"conflict exit code"* ]]
+}
+
+@test "-E rejects overflow value" {
+	run ${FLOCK} -n -E 99999999999999999999 ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"conflict exit code"* ]]
+}
+
+###############################################################################
+# Unlock (-u, --unlock)
+###############################################################################
+
 @test "-u unlocks existing exclusive lock" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${TIME} -p ${FLOCK} -u ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
+	hold_lock
+	result=$(get_elapsed ${FLOCK} -u ${LOCKFILE} true)
+	was_immediate "$result"
 }
+
 @test "-u unlocks existing shared lock" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.10 &
-	result=$(${TIME} -p ${FLOCK} -u ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
+	hold_lock "-s"
+	result=$(get_elapsed ${FLOCK} -u ${LOCKFILE} true)
+	was_immediate "$result"
 }
 
-# --unlock forcebly releases lock
 @test "--unlock unlocks existing exclusive lock" {
-	${FLOCK} ${LOCKFILE} sleep 0.10 &
-	result=$(${TIME} -p ${FLOCK} --unlock ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
-}
-@test "--unlock unlocks existing shared lock" {
-	${FLOCK} -s ${LOCKFILE} sleep 0.10 &
-	result=$(${TIME} -p ${FLOCK} --unlock ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.00 ]
+	hold_lock
+	result=$(get_elapsed ${FLOCK} --unlock ${LOCKFILE} true)
+	was_immediate "$result"
 }
 
-# Ensure -c may be provided
-@test "-c may be provided" {
-	result=$(${FLOCK} ${LOCKFILE} -c echo run)
+@test "--unlock unlocks existing shared lock" {
+	hold_lock "-s"
+	result=$(get_elapsed ${FLOCK} --unlock ${LOCKFILE} true)
+	was_immediate "$result"
+}
+
+###############################################################################
+# Command execution (-c, --command)
+###############################################################################
+
+@test "-c runs command through shell" {
+	result=$(${FLOCK} ${LOCKFILE} -c "echo run")
 	[ "$result" = run ]
 }
 
-# Ensure -c position correct if provided
-@test "-c must be provided after lock args and lockfile" {
-	${FLOCK} -c echo 1 ${LOCKFILE} || true
+@test "--command runs command through shell" {
+	result=$(${FLOCK} ${LOCKFILE} --command "echo run")
+	[ "$result" = run ]
 }
 
-# special file types
+@test "-c supports shell features (pipes)" {
+	result=$(${FLOCK} ${LOCKFILE} -c "echo hello | tr h H")
+	[ "$result" = Hello ]
+}
+
+@test "-c supports shell features (variable expansion)" {
+	result=$(${FLOCK} ${LOCKFILE} -c 'echo $((2 + 3))')
+	[ "$result" = 5 ]
+}
+
+@test "-c supports shell features (command substitution)" {
+	result=$(${FLOCK} ${LOCKFILE} -c 'echo $(echo nested)')
+	[ "$result" = nested ]
+}
+
+@test "-c requires exactly one argument" {
+	run ${FLOCK} ${LOCKFILE} -c echo extra args
+	[ "$status" -ne 0 ]
+}
+
+@test "-c must come after lockfile" {
+	run ${FLOCK} -c "echo 1" ${LOCKFILE}
+	[ "$status" -ne 0 ]
+}
+
+###############################################################################
+# Child exit status propagation
+###############################################################################
+
+@test "child exit 0 propagates to flock exit 0" {
+	run ${FLOCK} ${LOCKFILE} true
+	[ "$status" -eq 0 ]
+}
+
+@test "child exit 1 propagates to flock exit 1" {
+	run ${FLOCK} ${LOCKFILE} false
+	[ "$status" -eq 1 ]
+}
+
+@test "child custom exit code propagates" {
+	run ${FLOCK} ${LOCKFILE} sh -c "exit 42"
+	[ "$status" -eq 42 ]
+}
+
+@test "child exit 255 propagates" {
+	run ${FLOCK} ${LOCKFILE} sh -c "exit 255"
+	[ "$status" -eq 255 ]
+}
+
+@test "nonexistent command returns non-zero" {
+	run ${FLOCK} ${LOCKFILE} /nonexistent/command/that/does/not/exist
+	[ "$status" -ne 0 ]
+}
+
+@test "-c child exit code propagates" {
+	run ${FLOCK} ${LOCKFILE} -c "exit 7"
+	[ "$status" -eq 7 ]
+}
+
+###############################################################################
+# Lock file types
+###############################################################################
+
 @test "lock on existing file" {
 	touch ${LOCKFILE}
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	hold_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-@test "lock on non-existing file" {
+@test "lock creates non-existing file" {
 	rm -f ${LOCKFILE}
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	${FLOCK} ${LOCKFILE} true
+	[ -f ${LOCKFILE} ]
+}
+
+@test "lock on non-existing file blocks correctly" {
+	rm -f ${LOCKFILE}
+	${FLOCK} ${LOCKFILE} sleep 2 &
+	wait_for_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
 @test "lock on read-only file" {
 	touch ${LOCKFILE}
 	chmod 444 ${LOCKFILE}
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	rm -f ${LOCKFILE}
-	[ "$result" = 0.05 ]
+	hold_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
 @test "lock on write-only file" {
 	touch ${LOCKFILE}
 	chmod 222 ${LOCKFILE}
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	rm -f ${LOCKFILE}
-	[ "$result" = 0.05 ]
+	hold_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-@test "lock on dir" {
+@test "lock on directory" {
 	rm -f ${LOCKFILE}
 	mkdir -p ${LOCKFILE}
-	${FLOCK} ${LOCKFILE} sleep 0.05 &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	rm -rf  ${LOCKFILE}
-	[ "$result" = 0.05 ]
+	${FLOCK} ${LOCKFILE} sleep 2 &
+	wait_for_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-# fd mode
+@test "lock on file with spaces in path" {
+	local SPACEFILE="${LOCKFILE} with spaces"
+	touch "${SPACEFILE}"
+	${FLOCK} "${SPACEFILE}" sleep 2 &
+	local i=0
+	while [ $i -lt 50 ]; do
+		if ! ${FLOCK} -n "${SPACEFILE}" true 2>/dev/null; then break; fi
+		sleep 0.05; i=$((i + 1))
+	done
+	result=$(get_elapsed ${FLOCK} "${SPACEFILE}" true)
+	rm -f "${SPACEFILE}"
+	was_blocked "$result"
+}
+
+@test "lock file in non-existent directory fails" {
+	run ${FLOCK} /nonexistent/dir/lockfile true
+	[ "$status" -ne 0 ]
+}
+
+###############################################################################
+# File descriptor mode
+###############################################################################
+
 @test "lock on file descriptor" {
 	(
 		${FLOCK} -n 8 || exit 1
-		# commands executed under lock ...
-		sleep 0.05
+		sleep 2
 	) 8> ${LOCKFILE} &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	wait_for_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_blocked "$result"
 }
 
-@test "lock, then unlock on file descriptor" {
+@test "lock then unlock on file descriptor" {
 	(
 		${FLOCK} -n 8 || exit 1
-		# commands executed under lock ...
-		sleep 0.05
+		sleep 1
 		${FLOCK} -u 8 || exit 1
-		sleep 0.05
+		sleep 5
 	) 8> ${LOCKFILE} &
-	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-	[ "$result" = 0.05 ]
+	wait_for_lock
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	# Should be blocked for ~1s (until unlock), not ~6s (until subshell exit)
+	was_blocked "$result"
+	# Upper bound: must complete well before the holder exits at ~6s
+	awk "BEGIN { exit ($result < 4.0) ? 0 : 1 }"
+}
+
+@test "shared lock on file descriptor" {
+	(
+		${FLOCK} -s 8 || exit 1
+		sleep 2
+	) 8> ${LOCKFILE} &
+	sleep 0.2  # shared lock doesn't block nonblock probe, just wait briefly
+	# Another shared lock should be immediate
+	result=$(get_elapsed ${FLOCK} -s ${LOCKFILE} true)
+	was_immediate "$result"
+}
+
+@test "fd mode nonblock fails when fd is locked" {
+	(
+		${FLOCK} -n 8 || exit 1
+		sleep 2
+	) 8> ${LOCKFILE} &
+	wait_for_lock
+	run ${FLOCK} -n ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+@test "fd mode rejects empty string" {
+	run ${FLOCK} ""
+	[ "$status" -ne 0 ]
+}
+
+@test "fd mode rejects non-numeric argument" {
+	run ${FLOCK} abc
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"bad file descriptor"* ]]
+}
+
+@test "fd mode rejects negative fd" {
+	run ${FLOCK} -- -1
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"bad file descriptor"* ]]
+}
+
+@test "fd mode rejects overflow fd" {
+	run ${FLOCK} 99999999999999999999
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"bad file descriptor"* ]]
+}
+
+###############################################################################
+# Close-before-exec (-o, --close)
+###############################################################################
+
+@test "-o runs command successfully" {
+	result=$(${FLOCK} -o ${LOCKFILE} echo run)
+	[ "$result" = run ]
+}
+
+@test "--close runs command successfully" {
+	result=$(${FLOCK} --close ${LOCKFILE} echo run)
+	[ "$result" = run ]
+}
+
+@test "-o closes fd before exec so grandchildren don't inherit lock" {
+	# Without -o, a grandchild inherits the lock fd and holds the lock
+	# until it exits. With -o, the fd is closed before exec, so grandchild
+	# processes don't inherit it.
+	# Spawn a grandchild that outlives the flock parent, then verify
+	# another process can acquire the lock while the grandchild is alive.
+	${FLOCK} -o ${LOCKFILE} sh -c "sleep 5 &" &
+	FLOCK_PID=$!
+	wait $FLOCK_PID
+	# The grandchild (sleep 5) is still running but shouldn't hold the lock
+	run ${FLOCK} -n ${LOCKFILE} echo relocked
+	[ "$status" -eq 0 ]
+	[ "$output" = relocked ]
+}
+
+###############################################################################
+# Verbose (--verbose)
+###############################################################################
+
+@test "--verbose produces lock acquisition and timing output" {
+	result=$(${FLOCK} --verbose ${LOCKFILE} true 2>&1)
+	[[ "$result" == *"getting lock"* ]]
+	[[ "$result" == *"microseconds"* ]]
+}
+
+###############################################################################
+# Lock is released when holder exits
+###############################################################################
+
+@test "lock is released when holder process exits" {
+	${FLOCK} ${LOCKFILE} sleep 0.3 &
+	sleep 0.1
+	# Wait for the holder to finish
+	wait
+	# Now the lock should be free
+	result=$(get_elapsed ${FLOCK} ${LOCKFILE} true)
+	was_immediate "$result"
+}
+
+###############################################################################
+# Option combinations
+###############################################################################
+
+@test "-x -n combined: exclusive nonblock" {
+	hold_lock
+	run ${FLOCK} -x -n ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+@test "-s -n combined: shared nonblock succeeds with shared held" {
+	hold_lock "-s"
+	result=$(${FLOCK} -s -n ${LOCKFILE} echo run)
+	[ "$result" = run ]
+}
+
+@test "-s -n combined: shared nonblock fails with exclusive held" {
+	hold_lock
+	run ${FLOCK} -s -n ${LOCKFILE} echo run
+	[ "$status" -ne 0 ]
+}
+
+@test "last lock type flag wins (-s then -x)" {
+	hold_lock "-s"
+	# -s then -x: should try exclusive, which should block on shared
+	result=$(get_elapsed ${FLOCK} -s -x ${LOCKFILE} true)
+	was_blocked "$result"
+}
+
+@test "last lock type flag wins (-x then -s)" {
+	hold_lock "-s"
+	# -x then -s: should try shared, which should be immediate with shared held
+	result=$(get_elapsed ${FLOCK} -x -s ${LOCKFILE} true)
+	was_immediate "$result"
+}
+
+@test "-w with -E sets timeout exit code" {
+	hold_lock
+	run ${FLOCK} -w 0.1 -E 55 ${LOCKFILE} echo run
+	[ "$status" -eq 55 ]
+}
+
+@test "-n with -E 0 exits 0 on conflict" {
+	hold_lock
+	run ${FLOCK} -n -E 0 ${LOCKFILE} echo run
+	[ "$status" -eq 0 ]
+	# But the command should NOT have run
+	[[ "$output" != *"run"* ]]
 }

--- a/t/smartos.bats
+++ b/t/smartos.bats
@@ -10,19 +10,20 @@ LOCKFILE=`mktemp -t flock.XXXXXXXXXX`
 # 8
 # fails "flock: data error: Bad file number"
 @test "-n succeeds if lock is absent" {
-        rm -f ${LOCKFILE}
-        result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
-        [ "$result" = run ]
+	rm -f ${LOCKFILE}
+	result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
+	[ "$result" = run ]
 }
 
 # -u forcebly releases lock
 # 10
 # fails - does not release lock
 @test "-u unlocks existing shared lock" {
-        ${FLOCK} -s ${LOCKFILE} sleep 0.10 &
-        ${FLOCK} -u ${LOCKFILE} true
-        result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
-        [ "$result" = err ]
+	${FLOCK} -s ${LOCKFILE} sleep 1 &
+	sleep 0.2
+	${FLOCK} -u ${LOCKFILE} true
+	result=$(${FLOCK} -n ${LOCKFILE} echo run || echo err)
+	[ "$result" = err ]
 }
 
 # special file types
@@ -30,19 +31,21 @@ LOCKFILE=`mktemp -t flock.XXXXXXXXXX`
 # 12
 # fails "flock: data error: Bad file number"
 @test "lock on non-existing file" {
-        rm -f ${LOCKFILE}
-        ${FLOCK} ${LOCKFILE} sleep 0.05 &
-        result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-        [ "$result" = 0.05 ]
+	rm -f ${LOCKFILE}
+	${FLOCK} ${LOCKFILE} sleep 1 &
+	sleep 0.2
+	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
+	awk "BEGIN { exit ($result >= 0.3) ? 0 : 1 }"
 }
 
 # 15
 # fails "flock: data error: Bad file number"
 @test "lock on dir" {
-        rm -f ${LOCKFILE}
-        mkdir -p ${LOCKFILE}
-        ${FLOCK} ${LOCKFILE} sleep 0.05 &
-        result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
-        rm -rf  ${LOCKFILE}
-        [ "$result" = 0.05 ]
+	rm -f ${LOCKFILE}
+	mkdir -p ${LOCKFILE}
+	${FLOCK} ${LOCKFILE} sleep 1 &
+	sleep 0.2
+	result=$(${TIME} -p ${FLOCK} ${LOCKFILE} true 2>&1 | awk '/real/ {print $2}')
+	rm -rf ${LOCKFILE}
+	awk "BEGIN { exit ($result >= 0.3) ? 0 : 1 }"
 }


### PR DESCRIPTION
## Summary

- **GitHub Actions CI** with full test matrix: Ubuntu (GCC + Clang), macOS, and FreeBSD
- **Comprehensive test suite** expanded from ~30 timing-sensitive tests to 77 robust tests covering all flags, lock semantics, edge cases, and option combinations
- **Bug fixes** for GCC compilation errors, incorrect verbose timing, typos, and unvalidated user input
- **Build improvements** making ronn (man page generator) optional so `make && make install` works without extra dependencies

## Bug fixes

- `-h`/`--help` now exits 0 (was EX_USAGE/64) — fixes #15
- Fix `%1u` format specifier for `suseconds_t` causing GCC `-Werror` build failure — fixes #33 (supersedes #38)
- Fix verbose timing underflow: elapsed time was only subtracting `tv_usec`, producing wrong/negative values when lock acquisition crossed a second boundary
- Fix typo in error message: "waidpid" → "waitpid"
- Validate `-E` conflict exit code (was `atoi`, now rejects non-numeric and out-of-range values)
- Validate file descriptor argument in FD mode (previously `flock abc` silently locked stdin)

## Already fixed (can be closed)

- `-x` is already supported as a no-op (default is exclusive) — #9
- `-c` already wraps command with `$SHELL -c` as expected — #10

## Test suite

- Replaced exact timing comparisons (`[ "$result" = 0.05 ]`) with threshold-based helpers (`was_blocked`/`was_immediate`) — fixes #5, addresses #42
- Added `setup`/`teardown` with per-test lockfiles and background process cleanup
- New coverage: `-e` flag, `--nb` alias, `-c` shell features (pipes, variables, subst), child exit propagation, `-E` with `-n`/`-w`, `-o`/`--close`, `--verbose`, option combinations and flag precedence, file with spaces, nonexistent paths

## CI & build

- GitHub Actions replacing Travis — fixes #17
- Matrix: `ubuntu-latest` (gcc, clang), `macos-latest`, FreeBSD 15 via `vmactions/freebsd-vm`
- Man page build is now gracefully optional (warns instead of failing when `ronn` is absent) — fixes #41
- Actions pinned to v5 (Node.js 24)

## Documentation

- Added MacPorts install instructions to README — fixes #32 (supersedes #35)
- Documented `-c`, `-h`, `-V`, and `--verbose` options in man page

## Code quality

- Normalized indentation to tabs throughout `flock.c`
- Removed unnecessary `|=` for `fl.l_type` assignment in fcntl fallback
- Removed extraneous blank lines and fixed double-tab indentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-c/--command`, `-h/--help`, and `-V/--version` options; improved verbose timing output
  * Added CI that builds/tests across Linux, macOS, FreeBSD and generates man pages

* **Bug Fixes**
  * Fixed lock-type handling and corrected error messages
  * Tightened validation for exit-code and descriptor arguments

* **Documentation**
  * Expanded manpage OPTIONS and reordered verbosity docs
  * README notes that bats-core is required to run the test suite

* **Tests**
  * Significantly expanded and made tests timing-robust; improved setup/teardown and coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->